### PR TITLE
[DXF-1819] Redesign the header and make it responsive

### DIFF
--- a/packages/classic-webview/src/App.tsx
+++ b/packages/classic-webview/src/App.tsx
@@ -5,16 +5,9 @@ import { WinPage } from './pages/WinPage';
 import { usePage } from './hooks/usePage';
 import { Progress } from './components/progress';
 import { useGame } from './hooks/useGame';
-import { Logo } from '@hotandcold/webview-common/components/logo';
-import { sendMessageToDevvit } from './utils';
-import { cn, prettyNumber } from '@hotandcold/webview-common/utils';
-import { useConfirmation } from '@hotandcold/webview-common/hooks/useConfirmation';
-import { AnimatedNumber } from '@hotandcold/webview-common/components/timer';
-import { HelpMenu } from '@hotandcold/webview-common/components/helpMenu';
-import { useState } from 'react';
-import { HowToPlayModal } from './components/howToPlayModal';
+import { cn } from '@hotandcold/webview-common/utils';
+import { Header } from './components/header';
 import { LoadingPage } from './pages/LoadingPage';
-import { useSetUserSettings, useUserSettings } from './hooks/useUserSettings';
 
 const getPage = (page: Page) => {
   switch (page) {
@@ -33,16 +26,7 @@ const getPage = (page: Page) => {
 
 export const App = () => {
   const page = usePage();
-  const { layout, sortType, isUserOptedIntoReminders } = useUserSettings();
-  const setUserSettings = useSetUserSettings();
-  const { challengeUserInfo, challengeInfo, mode } = useGame();
-  const isActivelyPlaying =
-    challengeUserInfo?.guesses &&
-    challengeUserInfo?.guesses?.length > 0 &&
-    !challengeUserInfo?.solvedAtMs &&
-    !challengeUserInfo?.gaveUpAtMs;
-  const { showConfirmation } = useConfirmation();
-  const [howToPlayOpen, setHowToPlayOpen] = useState(false);
+  const { mode } = useGame();
   // const [friendsModalOpen, setFriendsModalOpen] = useState(false);
 
   return (
@@ -53,99 +37,9 @@ export const App = () => {
           'bg-[url(/assets/hardcore_background.png)] bg-cover bg-center bg-no-repeat bg-blend-multiply'
       )}
     >
-      <div>
-        <div className="flex h-4 items-center justify-between">
-          <p className="text-sm text-gray-500">
-            Players:&nbsp;
-            {/* 1 since the person viewing it could be the first and we don't count until there's a guess */}
-            {challengeInfo?.totalPlayers ? prettyNumber(challengeInfo.totalPlayers) : '1'}
-          </p>
-
-          <div className="flex gap-3">
-            <div className="flex items-end">
-              <p className="text-sm text-gray-500">Guesses:&nbsp;</p>
-              <AnimatedNumber
-                className="text-gray-500"
-                size={12.25}
-                value={challengeUserInfo?.guesses?.length ?? 0}
-              />
-            </div>
-            <HelpMenu
-              items={[
-                { name: 'How to Play', action: () => setHowToPlayOpen(true) },
-                {
-                  name: 'Toggle Size',
-                  action: () =>
-                    setUserSettings((x) => ({
-                      ...x,
-                      layout: layout === 'CONDENSED' ? 'EXPANDED' : 'CONDENSED',
-                    })),
-                },
-                {
-                  name: isUserOptedIntoReminders ? 'Unsubscribe' : 'Subscribe',
-                  action: () => {
-                    sendMessageToDevvit({
-                      type: 'TOGGLE_USER_REMINDER',
-                    });
-                  },
-                },
-                {
-                  name: `Sort by ${sortType === 'TIMESTAMP' ? 'Similarity' : 'Time'}`,
-                  disabled: !isActivelyPlaying,
-                  action: () => {
-                    setUserSettings((x) => ({
-                      ...x,
-                      sortType: x.sortType === 'SIMILARITY' ? 'TIMESTAMP' : 'SIMILARITY',
-                    }));
-                  },
-                },
-                {
-                  name: 'Hint',
-                  disabled: !isActivelyPlaying,
-                  action: async () => {
-                    const response = await showConfirmation({
-                      title: 'Are you sure?',
-                      description: `Receiving a hint will reduce your final score. Please use them sparingly to stay competitive on the leaderboard.`,
-                      confirmText: 'Request Hint',
-                      cancelText: 'Cancel',
-                    });
-
-                    if (!response.confirmed) return;
-
-                    sendMessageToDevvit({
-                      type: 'HINT_REQUEST',
-                    });
-                  },
-                },
-                {
-                  name: 'Give Up',
-                  disabled: !isActivelyPlaying,
-                  action: async () => {
-                    const response = await showConfirmation({
-                      title: 'Are you sure?',
-                      description: `This will end the game and reveal the word. You won't receive a score for this game and your streak will be reset.`,
-                      confirmText: 'Give Up',
-                      cancelText: 'Cancel',
-                    });
-
-                    if (!response.confirmed) return;
-
-                    sendMessageToDevvit({
-                      type: 'GIVE_UP_REQUEST',
-                    });
-                  },
-                },
-              ]}
-            />
-          </div>
-        </div>
-        <div className="-mt-4 mb-[10px] flex justify-center">
-          <Logo />
-        </div>
-      </div>
+      <Header />
       {getPage(page)}
       <Progress />
-      <HowToPlayModal isOpen={howToPlayOpen} onClose={() => setHowToPlayOpen(false)} />
       {/* <FriendsModal isOpen={friendsModalOpen} onClose={() => setFriendsModalOpen(false)} /> */}
     </div>
   );

--- a/packages/classic-webview/src/components/header.tsx
+++ b/packages/classic-webview/src/components/header.tsx
@@ -30,7 +30,12 @@ export const Header = () => {
         </div>
 
         <div className="flex flex-1 items-center justify-end gap-2">
-          <IconButton type="button" onClick={() => setHowToPlayOpen(true)} icon={<InfoIcon />}>
+          <IconButton
+            type="button"
+            onClick={() => setHowToPlayOpen(true)}
+            icon={<InfoIcon />}
+            aria-label="How to Play"
+          >
             How to Play
           </IconButton>
           <HelpMenu

--- a/packages/classic-webview/src/components/header.tsx
+++ b/packages/classic-webview/src/components/header.tsx
@@ -90,7 +90,7 @@ export const Header = () => {
                 action: async () => {
                   const response = await showConfirmation({
                     title: 'Are you sure?',
-                    description: `This will end the game and reveal the word. You won't receive a score for this game and your streak will be reset.`,
+                    description: `This will end the game and reveal the word. You won't receive a score for this game.`,
                     confirmText: 'Give Up',
                     cancelText: 'Cancel',
                   });

--- a/packages/classic-webview/src/components/header.tsx
+++ b/packages/classic-webview/src/components/header.tsx
@@ -1,0 +1,107 @@
+import { Logo } from '@hotandcold/webview-common/components/logo';
+import { HelpMenu } from '@hotandcold/webview-common/components/helpMenu';
+import { useConfirmation } from '@hotandcold/webview-common/hooks/useConfirmation';
+import { sendMessageToDevvit } from '../utils';
+import { useUserSettings, useSetUserSettings } from '../hooks/useUserSettings';
+import { useGame } from '../hooks/useGame';
+import { useState } from 'react';
+import type { UserSettings } from '@hotandcold/classic-shared';
+import { HowToPlayModal } from './howToPlayModal';
+import { IconButton } from '@hotandcold/webview-common/components/button';
+import { InfoIcon } from '@hotandcold/webview-common/components/icon';
+
+export const Header = () => {
+  const { layout, sortType, isUserOptedIntoReminders } = useUserSettings();
+  const setUserSettings = useSetUserSettings();
+  const { challengeUserInfo } = useGame();
+  const isActivelyPlaying =
+    challengeUserInfo?.guesses &&
+    challengeUserInfo?.guesses?.length > 0 &&
+    !challengeUserInfo?.solvedAtMs &&
+    !challengeUserInfo?.gaveUpAtMs;
+  const { showConfirmation } = useConfirmation();
+  const [howToPlayOpen, setHowToPlayOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <Logo />
+        </div>
+
+        <div className="flex flex-1 items-center justify-end gap-2">
+          <IconButton type="button" onClick={() => setHowToPlayOpen(true)} icon={<InfoIcon />}>
+            How to Play
+          </IconButton>
+          <HelpMenu
+            items={[
+              {
+                name: 'Toggle Size',
+                action: () =>
+                  setUserSettings((x: UserSettings) => ({
+                    ...x,
+                    layout: layout === 'CONDENSED' ? 'EXPANDED' : 'CONDENSED',
+                  })),
+              },
+              {
+                name: isUserOptedIntoReminders ? 'Unsubscribe' : 'Subscribe',
+                action: () => {
+                  sendMessageToDevvit({
+                    type: 'TOGGLE_USER_REMINDER',
+                  });
+                },
+              },
+              {
+                name: `Sort by ${sortType === 'TIMESTAMP' ? 'Similarity' : 'Time'}`,
+                disabled: !isActivelyPlaying,
+                action: () => {
+                  setUserSettings((x: UserSettings) => ({
+                    ...x,
+                    sortType: x.sortType === 'SIMILARITY' ? 'TIMESTAMP' : 'SIMILARITY',
+                  }));
+                },
+              },
+              {
+                name: 'Hint',
+                disabled: !isActivelyPlaying,
+                action: async () => {
+                  const response = await showConfirmation({
+                    title: 'Are you sure?',
+                    description: `Receiving a hint will reduce your final score. Please use them sparingly to stay competitive on the leaderboard.`,
+                    confirmText: 'Request Hint',
+                    cancelText: 'Cancel',
+                  });
+
+                  if (!response.confirmed) return;
+
+                  sendMessageToDevvit({
+                    type: 'HINT_REQUEST',
+                  });
+                },
+              },
+              {
+                name: 'Give Up',
+                disabled: !isActivelyPlaying,
+                action: async () => {
+                  const response = await showConfirmation({
+                    title: 'Are you sure?',
+                    description: `This will end the game and reveal the word. You won't receive a score for this game and your streak will be reset.`,
+                    confirmText: 'Give Up',
+                    cancelText: 'Cancel',
+                  });
+
+                  if (!response.confirmed) return;
+
+                  sendMessageToDevvit({
+                    type: 'GIVE_UP_REQUEST',
+                  });
+                },
+              },
+            ]}
+          />
+        </div>
+      </div>
+      <HowToPlayModal isOpen={howToPlayOpen} onClose={() => setHowToPlayOpen(false)} />
+    </>
+  );
+};

--- a/packages/webview-common/package.json
+++ b/packages/webview-common/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./components/button": "./src/components/button.tsx",
     "./components/helpMenu": "./src/components/helpMenu.tsx",
+    "./components/icon": "./src/components/icon.tsx",
     "./components/logo": "./src/components/logo.tsx",
     "./components/modal": "./src/components/modal.tsx",
     "./components/switcher": "./src/components/switcher.tsx",

--- a/packages/webview-common/src/components/button.tsx
+++ b/packages/webview-common/src/components/button.tsx
@@ -52,6 +52,7 @@ export const IconButton = ({
   ...rest
 }: ComponentProps<'button'> & {
   icon: React.ReactNode;
+  'aria-label': string; // Require label for accessibility since the text is often hidden.
 }) => (
   <button
     className={cn(

--- a/packages/webview-common/src/components/button.tsx
+++ b/packages/webview-common/src/components/button.tsx
@@ -44,3 +44,23 @@ export const SecondaryButton = ({ children, className, ...rest }: ComponentProps
     </button>
   );
 };
+
+export const IconButton = ({
+  children,
+  className,
+  icon,
+  ...rest
+}: ComponentProps<'button'> & {
+  icon: React.ReactNode;
+}) => (
+  <button
+    className={cn(
+      'flex items-center gap-2 rounded-full bg-gray-50 p-3 text-current sm:px-3 sm:py-2 dark:bg-black',
+      className
+    )}
+    {...rest}
+  >
+    {icon}
+    <span className="hidden sm:inline">{children}</span>
+  </button>
+);

--- a/packages/webview-common/src/components/helpMenu.tsx
+++ b/packages/webview-common/src/components/helpMenu.tsx
@@ -1,10 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-
-const HamburgerIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="11" fill="currentColor">
-    <path d="M13.667 6.333H.333v-1h13.334v1Zm0-5.666H.333v1h13.334v-1Zm0 9.333H.333v1h13.334v-1Z" />
-  </svg>
-);
+import { IconButton } from './button';
+import { HamburgerIcon } from './icon';
 
 export const HelpMenu = ({
   items,
@@ -106,17 +102,16 @@ export const HelpMenu = ({
 
   return (
     <div className="relative text-gray-900 dark:text-white" ref={menuRef} onKeyDown={handleKeyDown}>
-      <button
+      <IconButton
         onClick={() => setToggled((x) => !x)}
         aria-expanded={toggled}
         aria-haspopup="true"
         aria-label="Menu"
         type="button"
-        className="flex items-center gap-2 rounded-full bg-gray-50 px-4 py-3 text-current sm:px-3 sm:py-2 dark:bg-black"
+        icon={<HamburgerIcon />}
       >
-        <HamburgerIcon />
-        <span className="hidden sm:inline">Menu</span>
-      </button>
+        Menu
+      </IconButton>
 
       {toggled && (
         <div

--- a/packages/webview-common/src/components/icon.tsx
+++ b/packages/webview-common/src/components/icon.tsx
@@ -1,0 +1,14 @@
+export const InfoIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor">
+    <path
+      fill="#fff"
+      d="M8 16a8 8 0 1 1 8-8 8.009 8.009 0 0 1-8 8ZM8 1a7 7 0 1 0 7 7 7.008 7.008 0 0 0-7-7Zm-.434 4.564a.846.846 0 0 1-.312-.314.888.888 0 0 1 0-.872.831.831 0 0 1 .312-.31.88.88 0 0 1 1.187.313c.078.13.119.28.117.432A.865.865 0 0 1 8 5.68a.85.85 0 0 1-.434-.116Zm1.083 6.77H7.36V6.5h1.291l-.002 5.835Z"
+    />
+  </svg>
+);
+
+export const HamburgerIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="11" fill="currentColor">
+    <path d="M13.667 6.333H.333v-1h13.334v1Zm0-5.666H.333v1h13.334v-1Zm0 9.333H.333v1h13.334v-1Z" />
+  </svg>
+);


### PR DESCRIPTION
## 💸 TL;DR
* Creates a `Header` component 
* Makes the header menu and "how to play" button labels responsive
* Moves the logo to the left
* Adds the "how to play" modal to the `Header` component
* Creates an `IconButton` component that hides the text in smaller screens

## 🧪 Testing Steps / Validation

https://github.com/user-attachments/assets/e6357d18-a9e8-4b1e-a0c8-e380c42f6d1b
