### PR TITLE
Fixes issue where you can't post a new challenge

### DIFF
--- a/packages/classic/src/core/challenge.tsx
+++ b/packages/classic/src/core/challenge.tsx
@@ -14,6 +14,9 @@ import {
 import { GameMode } from '@hotandcold/classic-shared';
 
 import { Post, RedisClient, RichTextBuilder } from '@devvit/public-api';
+// For some reason <Preview /> requires this import, but the import is being found as unused.
+// Suppress the check for it
+import { Devvit } from '@devvit/public-api'; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 export * as Challenge from './challenge.js';
 


### PR DESCRIPTION
## 💸 TL;DR
Fixes the issue where you can't post a new challenge. It was a weird hidden dependency that the AI always wanted to add, but the linter always wanted to remove. I added a comment to suppress the lint error so hopefully it won't break again.