### PR TITLE
[DXF-1813] Update layout and stats on win/lose page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11133,7 +11133,7 @@
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@devvit/public-api": "0.11.13",
+        "@devvit/public-api": "^0.11.13",
         "@hotandcold/classic-shared": "*",
         "@hotandcold/shared": "*",
         "luxon": "^3.6.1"

--- a/packages/classic-webview/src/pages/WinPage.tsx
+++ b/packages/classic-webview/src/pages/WinPage.tsx
@@ -3,7 +3,7 @@ import { useGame } from '../hooks/useGame';
 import { sendMessageToDevvit } from '../utils';
 import { cn, getPrettyDuration } from '@hotandcold/webview-common/utils';
 import { useDevvitListener } from '../hooks/useDevvitListener';
-import PillSwitch from '@hotandcold/webview-common/components/switcher';
+import { Tablist } from '@hotandcold/webview-common/components/tablist';
 import { AnimatedNumber } from '@hotandcold/webview-common/components/timer';
 import { useUserSettings } from '../hooks/useUserSettings';
 import { ScoreBreakdownModal } from '../components/scoreBreakdownModal';
@@ -128,7 +128,7 @@ export const WinPage = () => {
     <>
       <div className="flex min-h-0 flex-1 flex-col gap-4">
         <div className="flex justify-center">
-          <PillSwitch
+          <Tablist
             activeIndex={activeIndex}
             onChange={setActiveIndex}
             items={[{ name: 'My Stats' }, { name: 'Challenge Stats' }, { name: 'Leaderboard' }]}

--- a/packages/classic-webview/src/pages/WinPage.tsx
+++ b/packages/classic-webview/src/pages/WinPage.tsx
@@ -92,14 +92,17 @@ export const WinPage = () => {
                   <StatCard
                     title={
                       <>
-                        Score (
-                        <button
-                          className="cursor-pointer text-inherit underline"
-                          onClick={() => setIsScoreBreakdownOpen(true)}
-                        >
-                          breakdown
-                        </button>
-                        )
+                        Score{' '}
+                        <span className="whitespace-nowrap">
+                          (
+                          <button
+                            className="cursor-pointer text-inherit underline"
+                            onClick={() => setIsScoreBreakdownOpen(true)}
+                          >
+                            breakdown
+                          </button>
+                          )
+                        </span>
                       </>
                     }
                     value={challengeUserInfo.score?.finalScore ?? 0}

--- a/packages/classic-webview/src/pages/WinPage.tsx
+++ b/packages/classic-webview/src/pages/WinPage.tsx
@@ -138,14 +138,10 @@ export const WinPage = () => {
         <div className="mx-auto w-full max-w-xl px-4">
           {activeIndex === 0 && (
             <div className="flex flex-col items-center gap-6 text-center">
-              <div className="flex flex-col items-center gap-2">
-                <h1 className="text-xl font-bold text-white">
-                  {didWin ? 'Congratulations!' : 'Nice Try!'}
-                </h1>
-                <p className="text-lg font-semibold">
-                  The word was: <span className="text-[#dd4c4c]">{word.word}</span>
-                </p>
-              </div>
+              <h1 className="text-2xl font-bold text-white">
+                {didWin ? 'Congratulations!' : 'Nice Try!'} The word was:{' '}
+                <span className="text-[#dd4c4c]">{word.word}</span>
+              </h1>
 
               <div className="flex flex-col items-center gap-2">
                 {didWin ? (

--- a/packages/classic-webview/src/pages/WinPage.tsx
+++ b/packages/classic-webview/src/pages/WinPage.tsx
@@ -70,7 +70,7 @@ export const WinPage = () => {
 
   return (
     <>
-      <div className="flex flex-1 flex-col gap-4">
+      <div className="flex flex-1 flex-col gap-4 px-4">
         <div className="mx-auto">
           <Tablist
             activeIndex={activeIndex}
@@ -79,9 +79,9 @@ export const WinPage = () => {
           />
         </div>
 
-        <div className="mx-auto w-full max-w-xl px-4">
+        <div className="mx-auto w-full max-w-xl flex-auto px-4">
           {activeIndex === 0 && (
-            <div className="flex flex-col items-center gap-8">
+            <div className="flex h-full flex-col items-center justify-center gap-8">
               <h1 className="text-center text-2xl font-bold text-white">
                 {didWin ? 'Congratulations!' : 'Nice Try!'} The word was:{' '}
                 <span className="text-[#dd4c4c]">{word.word}</span>

--- a/packages/classic-webview/src/pages/WinPage.tsx
+++ b/packages/classic-webview/src/pages/WinPage.tsx
@@ -24,12 +24,7 @@ const StatCard = ({
     <div className="pb-1">{title}</div>
     <div>
       <span className="truncate text-2xl font-bold text-black dark:text-white">{value}</span>
-      {valueSubtext && (
-        <>
-          {' '}
-          <span>{valueSubtext}</span>
-        </>
-      )}
+      {valueSubtext && <> {valueSubtext}</>}
     </div>
   </div>
 );

--- a/packages/classic-webview/src/pages/WinPage.tsx
+++ b/packages/classic-webview/src/pages/WinPage.tsx
@@ -4,7 +4,6 @@ import { sendMessageToDevvit } from '../utils';
 import { cn, getPrettyDuration } from '@hotandcold/webview-common/utils';
 import { useDevvitListener } from '../hooks/useDevvitListener';
 import { Tablist } from '@hotandcold/webview-common/components/tablist';
-import { AnimatedNumber } from '@hotandcold/webview-common/components/timer';
 import { useUserSettings } from '../hooks/useUserSettings';
 import { ScoreBreakdownModal } from '../components/scoreBreakdownModal';
 
@@ -15,79 +14,24 @@ const prettyNumber = (num: number): string => {
 const StatCard = ({
   title,
   value,
-  icon: Icon,
+  valueSubtext,
 }: {
-  title: string;
+  title: React.ReactNode;
   value: string | number;
-  icon: React.ComponentType;
+  valueSubtext?: string;
 }) => (
-  <div className="flex flex-col items-start gap-2 rounded-lg bg-gray-800 p-3">
-    <div className="text-xs text-gray-400">{title}</div>
-    <div className="flex gap-1 text-left">
-      <div className="flex-shrink-0">
-        <Icon />
-      </div>
-      <div className="truncate font-bold text-white">{value}</div>
+  <div className="rounded-lg bg-gray-200 px-4 py-2 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+    <div className="pb-1">{title}</div>
+    <div>
+      <span className="truncate text-2xl font-bold text-black dark:text-white">{value}</span>
+      {valueSubtext && (
+        <>
+          {' '}
+          <span>{valueSubtext}</span>
+        </>
+      )}
     </div>
   </div>
-);
-
-const TimeIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="h-5 w-5"
-    viewBox="0 0 24 24"
-    strokeWidth="2"
-    stroke="currentColor"
-    fill="none"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-    <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-    <path d="M12 7v5l3 3" />
-  </svg>
-);
-
-const GuessIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="h-5 w-5"
-    viewBox="0 0 24 24"
-    strokeWidth="2"
-    stroke="currentColor"
-    fill="none"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-    <path d="M11 5h2" />
-    <path d="M5 11h14" />
-    <path d="M15 11v-4a2 2 0 0 0 -4 0" />
-    <path d="M5 11c0 5.5 2.5 10 7 10" />
-    <path d="M19 11c0 5.5 -2.5 10 -7 10" />
-    <path d="M12 21v-10" />
-  </svg>
-);
-
-const ThermometerIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  >
-    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-    <path d="M18 7v12a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2v-12l6 -4z" />
-    <path d="M10 13l2 -1l2 1" />
-    <path d="M10 17l2 -1l2 1" />
-    <path d="M10 9l2 -1l2 1" />
-  </svg>
 );
 
 export const WinPage = () => {
@@ -111,8 +55,8 @@ export const WinPage = () => {
   if (!word) throw new Error('No correct word found?');
 
   const calculatePercentageOutperformed = (rank: number, totalPlayers: number): number => {
-    if (totalPlayers <= 1 || rank <= 0) return 0;
     if (rank === 1) return 100;
+    if (totalPlayers <= 1 || rank <= 0) return 0;
 
     const playersBeaten = totalPlayers - rank;
     const percentage = (playersBeaten / (totalPlayers - 1)) * 100;
@@ -126,8 +70,8 @@ export const WinPage = () => {
 
   return (
     <>
-      <div className="flex min-h-0 flex-1 flex-col gap-4">
-        <div className="flex justify-center">
+      <div className="flex flex-1 flex-col gap-4">
+        <div className="mx-auto">
           <Tablist
             activeIndex={activeIndex}
             onChange={setActiveIndex}
@@ -137,53 +81,31 @@ export const WinPage = () => {
 
         <div className="mx-auto w-full max-w-xl px-4">
           {activeIndex === 0 && (
-            <div className="flex flex-col items-center gap-6 text-center">
-              <h1 className="text-2xl font-bold text-white">
+            <div className="flex flex-col items-center gap-8">
+              <h1 className="text-center text-2xl font-bold text-white">
                 {didWin ? 'Congratulations!' : 'Nice Try!'} The word was:{' '}
                 <span className="text-[#dd4c4c]">{word.word}</span>
               </h1>
 
-              <div className="flex flex-col items-center gap-2">
-                {didWin ? (
-                  <div className="flex flex-col items-center justify-center">
-                    <p className="mb-2 text-sm font-bold">
-                      Your Score (
-                      <span
-                        className="cursor-pointer text-gray-500 underline"
-                        onClick={() => setIsScoreBreakdownOpen(true)}
-                      >
-                        breakdown
-                      </span>
-                      )
-                    </p>
-
-                    <AnimatedNumber
-                      size={40}
-                      value={challengeUserInfo.score?.finalScore ?? 0}
-                      animateOnMount
-                    />
-                  </div>
-                ) : (
-                  <span className="text-4xl">--</span>
+              <div className="flex gap-2 sm:gap-4">
+                {didWin && (
+                  <StatCard
+                    title={
+                      <>
+                        Score (
+                        <button
+                          className="cursor-pointer text-inherit underline"
+                          onClick={() => setIsScoreBreakdownOpen(true)}
+                        >
+                          breakdown
+                        </button>
+                        )
+                      </>
+                    }
+                    value={challengeUserInfo.score?.finalScore ?? 0}
+                    valueSubtext={playerRank > 0 ? `Top ${percentageOutperformed}%` : undefined}
+                  />
                 )}
-
-                <p className="text-sm text-gray-400">
-                  {didWin ? (
-                    totalPlayers === 1 ? (
-                      <span>You're the first player to solve today's challenge!</span>
-                    ) : (
-                      <span>
-                        That's better than {playerRank > 0 ? percentageOutperformed : '--'}% of
-                        players!
-                      </span>
-                    )
-                  ) : (
-                    <span>Play again tomorrow!</span>
-                  )}
-                </p>
-              </div>
-
-              <div className="w-50% grid grid-cols-2 gap-4">
                 <StatCard
                   title="Time to Solve"
                   value={
@@ -192,23 +114,14 @@ export const WinPage = () => {
                       new Date(challengeUserInfo.solvedAtMs ?? challengeUserInfo.gaveUpAtMs!)
                     ) ?? '--'
                   }
-                  icon={TimeIcon}
                 />
                 <StatCard
                   title="Rank"
                   value={didWin ? `#${leaderboardData?.userRank.score ?? '--'}` : '--'}
-                  icon={ThermometerIcon}
                 />
               </div>
 
               <div className="flex flex-col gap-3">
-                {/* <button
-                className="w-full rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
-                onClick={() => {}}
-              >
-                Share Word Journey
-              </button> */}
-
                 <label className="flex cursor-pointer items-center justify-center gap-2 px-4 py-2">
                   <input
                     type="checkbox"
@@ -231,64 +144,19 @@ export const WinPage = () => {
           {activeIndex === 1 && (
             <div className="flex flex-col gap-6">
               <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-                <StatCard
-                  title="Total Players"
-                  value={challengeInfo?.totalPlayers ?? 0}
-                  icon={GuessIcon}
-                />
-                <StatCard
-                  title="Total Solves"
-                  value={challengeInfo?.totalSolves ?? 0}
-                  icon={GuessIcon}
-                />
-                <StatCard
-                  title="Total Guesses"
-                  value={challengeInfo?.totalGuesses ?? 0}
-                  icon={GuessIcon}
-                />
-                <StatCard
-                  title="Total Hints"
-                  value={challengeInfo?.totalHints ?? 0}
-                  icon={GuessIcon}
-                />
-                <StatCard
-                  title="Give Ups"
-                  value={challengeInfo?.totalGiveUps ?? 0}
-                  icon={GuessIcon}
-                />
+                <StatCard title="Total Players" value={challengeInfo?.totalPlayers ?? 0} />
+                <StatCard title="Total Solves" value={challengeInfo?.totalSolves ?? 0} />
+                <StatCard title="Total Guesses" value={challengeInfo?.totalGuesses ?? 0} />
+                <StatCard title="Total Hints" value={challengeInfo?.totalHints ?? 0} />
+                <StatCard title="Give Ups" value={challengeInfo?.totalGiveUps ?? 0} />
                 <StatCard
                   title="Solve Rate"
                   value={`${Math.round(((challengeInfo?.totalSolves ?? 0) / (challengeInfo?.totalPlayers ?? 1)) * 100)}%`}
-                  icon={() => (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-5 w-5"
-                      viewBox="0 0 24 24"
-                      strokeWidth="2"
-                      stroke="currentColor"
-                      fill="none"
-                    >
-                      <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
-                      <path d="M12 7v5l3 3" />
-                    </svg>
-                  )}
                 />
                 <StatCard
                   title="Average Guesses"
                   value={Math.round(
                     (challengeInfo?.totalGuesses ?? 0) / (challengeInfo?.totalPlayers ?? 1)
-                  )}
-                  icon={() => (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-5 w-5"
-                      viewBox="0 0 24 24"
-                      strokeWidth="2"
-                      stroke="currentColor"
-                      fill="none"
-                    >
-                      <path d="M3 12h4l3 8l4 -16l3 8h4" />
-                    </svg>
                   )}
                 />
               </div>

--- a/packages/webview-common/package.json
+++ b/packages/webview-common/package.json
@@ -9,7 +9,7 @@
     "./components/icon": "./src/components/icon.tsx",
     "./components/logo": "./src/components/logo.tsx",
     "./components/modal": "./src/components/modal.tsx",
-    "./components/switcher": "./src/components/switcher.tsx",
+    "./components/tablist": "./src/components/tablist.tsx",
     "./components/timer": "./src/components/timer.tsx",
     "./components/wordInput": "./src/components/wordInput.tsx",
     "./hooks/useConfirmation": "./src/hooks/useConfirmation.tsx",

--- a/packages/webview-common/src/components/tablist.tsx
+++ b/packages/webview-common/src/components/tablist.tsx
@@ -25,7 +25,7 @@ export const Tablist = ({ activeIndex, onChange, items }: TablistProps) => {
           onClick={() => onChange(index)}
           onKeyDown={(e) => handleKeyDown(e, index)}
           className={cn(
-            `border-b px-6 py-2 text-sm font-medium outline-none ring-0 transition-colors duration-200 ease-in-out`,
+            `border-b px-3 py-2 text-sm font-medium outline-none ring-0 transition-colors duration-200 ease-in-out sm:px-6`,
             activeIndex === index
               ? 'border-current text-black dark:text-white'
               : 'border-gray-200 hover:border-current hover:text-slate-300 dark:border-gray-800'

--- a/packages/webview-common/src/components/tablist.tsx
+++ b/packages/webview-common/src/components/tablist.tsx
@@ -1,13 +1,13 @@
 import { KeyboardEvent } from 'react';
 import { cn } from '@hotandcold/webview-common/utils';
 
-interface PillSwitchProps {
+interface TablistProps {
   activeIndex: number;
   onChange: (index: number) => void;
   items: Array<{ name: string }>;
 }
 
-export const PillSwitch = ({ activeIndex, onChange, items }: PillSwitchProps) => {
+export const Tablist = ({ activeIndex, onChange, items }: TablistProps) => {
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
     if (e.key === 'Enter') {
       onChange(index);
@@ -15,7 +15,7 @@ export const PillSwitch = ({ activeIndex, onChange, items }: PillSwitchProps) =>
   };
 
   return (
-    <div role="tablist" className="inline-flex rounded-lg p-1">
+    <div role="tablist" className="inline-flex text-gray-600 dark:text-gray-400">
       {items.map((item, index) => (
         <button
           key={item.name}
@@ -25,8 +25,10 @@ export const PillSwitch = ({ activeIndex, onChange, items }: PillSwitchProps) =>
           onClick={() => onChange(index)}
           onKeyDown={(e) => handleKeyDown(e, index)}
           className={cn(
-            `rounded-md px-4 py-2 text-sm font-medium outline-none ring-0 transition-all duration-200 ease-in-out`,
-            activeIndex === index ? 'bg-gray-800 text-white' : 'text-gray-400 hover:text-slate-300'
+            `border-b px-6 py-2 text-sm font-medium outline-none ring-0 transition-colors duration-200 ease-in-out`,
+            activeIndex === index
+              ? 'border-current text-black dark:text-white'
+              : 'border-gray-200 hover:border-current hover:text-slate-300 dark:border-gray-800'
           )}
         >
           {item.name}
@@ -35,5 +37,3 @@ export const PillSwitch = ({ activeIndex, onChange, items }: PillSwitchProps) =>
     </div>
   );
 };
-
-export default PillSwitch;


### PR DESCRIPTION
## 💸 TL;DR
* Updates the content and stats styles to match the new designs
  * Tabs style
  * Page title
  * Stats text size and remove icons
* Ran `npm i` which update the `package-lock.json` to reflect the recent `package.json` changes 

**Note:** I'll submit a PR for the call to action for hardcore mode and update the checkbox style in the next PR

## 🧪 Testing Steps / Validation
### Win page
**desktop**
<img width="761" alt="image" src="https://github.com/user-attachments/assets/8d8df868-1ee1-4f70-b07d-baad0c02c9eb" />

**mobile**
<img width="391" alt="image" src="https://github.com/user-attachments/assets/f32bff15-92cd-4fa5-86cf-bbfd200ae279" />

### Give up
**desktop**
<img width="675" alt="image" src="https://github.com/user-attachments/assets/ca8605c8-755e-490e-8cbd-8905fab078c6" />

**mobile**
<img width="390" alt="image" src="https://github.com/user-attachments/assets/14121383-bd7e-420c-b7ad-32ed002301be" />
