### PR TITLE
Prevents hints from being given in hardcore mode.

### DIFF
--- a/packages/classic-webview/src/components/header.tsx
+++ b/packages/classic-webview/src/components/header.tsx
@@ -95,7 +95,7 @@ export const Header = () => {
               },
               {
                 name: 'Hint',
-                disabled: !isActivelyPlaying,
+                disabled: !isActivelyPlaying || isHardcore,
                 action: async () => {
                   const response = await showConfirmation({
                     title: 'Are you sure?',

--- a/packages/classic-webview/src/components/header.tsx
+++ b/packages/classic-webview/src/components/header.tsx
@@ -94,7 +94,7 @@ export const Header = () => {
                 },
               },
               {
-                name: 'Hint',
+                name: isHardcore ? 'No hints in HARDCORE!' : 'Hint',
                 disabled: !isActivelyPlaying || isHardcore,
                 action: async () => {
                   const response = await showConfirmation({

--- a/packages/classic/src/main.tsx
+++ b/packages/classic/src/main.tsx
@@ -230,7 +230,9 @@ Devvit.addCustomPostType({
                   // We remove the UI affordance for hints in hardcore mode.
                   // However, it's possible for users to manually send messages from a webview via the console.
                   // So let's do some defensive programming here and make sure these users can't get hints.
-                  context.ui.showToast('No hints in hardcore mode!');
+                  context.ui.showToast(
+                    'Nice try using the console to send an event! Alas, we thought of that.'
+                  );
                   break;
                 }
 

--- a/packages/classic/src/main.tsx
+++ b/packages/classic/src/main.tsx
@@ -226,6 +226,14 @@ Devvit.addCustomPostType({
                 break;
               }
               case 'HINT_REQUEST': {
+                if (challengeIdentifier.mode === 'hardcore') {
+                  // We remove the UI affordance for hints in hardcore mode.
+                  // However, it's possible for users to manually send messages from a webview via the console.
+                  // So let's do some defensive programming here and make sure these users can't get hints.
+                  context.ui.showToast('No hints in hardcore mode!');
+                  break;
+                }
+
                 try {
                   sendMessageToWebview(context, {
                     type: 'HINT_RESPONSE',

--- a/packages/webview-common/src/components/helpMenu.tsx
+++ b/packages/webview-common/src/components/helpMenu.tsx
@@ -115,7 +115,7 @@ export const HelpMenu = ({
 
       {toggled && (
         <div
-          className="absolute right-0 top-full z-[10000] mt-1 w-36 rounded-md border border-gray-800 bg-gray-900 py-1 shadow-lg"
+          className="absolute right-0 top-full z-[10000] mt-1 w-48 rounded-md border border-gray-800 bg-gray-900 py-1 shadow-lg"
           role="menu"
           aria-orientation="vertical"
           aria-labelledby="menu-button"


### PR DESCRIPTION
## 💸 TL;DR
Prevents hints from being given in hardcore mode. Both changes UI affordance to prevent most users from getting hints **and** has the backend reject hint requests when it receives hint request messages, as users can use the console to send messages.

![Screenshot 2025-04-25 at 2 36 17 PM](https://github.com/user-attachments/assets/b430cac8-9233-4a1c-a582-0661f643671c)
