### PR TITLE
Refactor context providers

### DIFF
--- a/packages/classic-webview/src/hooks/useAppState.tsx
+++ b/packages/classic-webview/src/hooks/useAppState.tsx
@@ -1,0 +1,119 @@
+import { Game, HardcoreAccessStatus } from '@hotandcold/classic-shared';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { useMocks } from './useMocks';
+import { useDevvitListener } from './useDevvitListener';
+import { sendMessageToDevvit } from '../utils';
+import { logger } from '../utils/logger';
+import { useModal } from './useModal';
+import { useSetPage } from './usePage';
+
+type AppState = {
+  game: Partial<Game>;
+  hardcoreAccess: HardcoreAccessStatus;
+};
+
+type AppStateContext = {
+  appState: AppState;
+  setGame: (game: Partial<Game>) => void;
+  setAccess: (access: HardcoreAccessStatus) => void;
+};
+
+const appStateContext = createContext<AppStateContext | null>(null);
+
+export const AppStateContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const mocks = useMocks();
+  const { closeModal } = useModal();
+  const setPage = useSetPage();
+
+  const [game, setGame] = useState<Partial<Game>>(mocks.getMock('mocks')?.game ?? {});
+  const [access, setAccess] = useState<HardcoreAccessStatus>({ status: 'inactive' });
+
+  const initResponse = useDevvitListener('GAME_INIT_RESPONSE');
+  const submissionResponse = useDevvitListener('WORD_SUBMITTED_RESPONSE');
+  const hintResponse = useDevvitListener('HINT_RESPONSE');
+  const giveUpResponse = useDevvitListener('GIVE_UP_RESPONSE');
+  const hardcoreAccessInitResponse = useDevvitListener('HARDCORE_ACCESS_INIT_RESPONSE');
+  const productPurchaseResponse = useDevvitListener('PURCHASE_PRODUCT_SUCCESS_RESPONSE');
+
+  // Just in case the game is not initialized
+  // This is old code left in for safety
+  useEffect(() => {
+    sendMessageToDevvit({
+      type: 'GAME_INIT',
+    });
+  }, []);
+
+  useEffect(() => {
+    logger.log('Init response: ', initResponse);
+    if (initResponse) {
+      setGame(initResponse);
+    }
+  }, [initResponse]);
+
+  useEffect(() => {
+    logger.log('Submission response: ', submissionResponse);
+    if (submissionResponse) {
+      setGame(submissionResponse);
+    }
+  }, [submissionResponse]);
+
+  useEffect(() => {
+    logger.log('Hint response: ', hintResponse);
+    if (hintResponse) {
+      setGame(hintResponse);
+    }
+  }, [hintResponse]);
+
+  useEffect(() => {
+    logger.log('Give up response: ', giveUpResponse);
+    if (giveUpResponse) {
+      setGame(giveUpResponse);
+    }
+  }, [giveUpResponse]);
+
+  useEffect(() => {
+    logger.log('Hardcore access init response: ', hardcoreAccessInitResponse);
+    if (hardcoreAccessInitResponse?.hardcoreAccessStatus != null) {
+      setAccess(hardcoreAccessInitResponse.hardcoreAccessStatus);
+    }
+  }, [hardcoreAccessInitResponse, setAccess]);
+
+  // When a purchase is successful, update state and close the "Unlock Hardcore" modal
+  useEffect(() => {
+    logger.log('Product purchase response: ', productPurchaseResponse);
+    if (productPurchaseResponse != null) {
+      setAccess(productPurchaseResponse.access);
+      closeModal();
+    }
+  }, [productPurchaseResponse, setAccess, closeModal]);
+
+  useEffect(() => {
+    if (
+      // Keep in sync with usePage's initializer
+      game.challengeUserInfo?.solvedAtMs ||
+      game.challengeUserInfo?.gaveUpAtMs
+    ) {
+      setPage('win');
+    } else if (game.mode === 'hardcore' && access.status === 'inactive') {
+      setPage('unlock-hardcore');
+    } else {
+      setPage('play');
+    }
+  }, [game, access, setPage]);
+
+  const value: AppStateContext = {
+    appState: { game, hardcoreAccess: access },
+    setGame,
+    setAccess,
+  };
+
+  return <appStateContext.Provider value={value}>{children}</appStateContext.Provider>;
+};
+
+export const useAppState = () => {
+  const context = useContext(appStateContext);
+  if (context === null) {
+    throw new Error('useAppState must be used within an AppStateContextProvider');
+  }
+  return context;
+};

--- a/packages/classic-webview/src/hooks/useGame.tsx
+++ b/packages/classic-webview/src/hooks/useGame.tsx
@@ -1,64 +1,13 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext } from 'react';
 import { Game } from '@hotandcold/classic-shared';
-import { sendMessageToDevvit } from '../utils';
-import { useDevvitListener } from './useDevvitListener';
-import { logger } from '../utils/logger';
-import { useMocks } from './useMocks';
+import { useAppState } from './useAppState';
 
 const GameContext = createContext<Partial<Game>>({});
-const GameUpdaterContext = createContext<React.Dispatch<
-  React.SetStateAction<Partial<Game>>
-> | null>(null);
 // foo to trigger rebuild
 export const GameContextProvider = ({ children }: { children: React.ReactNode }) => {
-  const mocks = useMocks();
-  const [game, setGame] = useState<Partial<Game>>(mocks.getMock('mocks')?.game ?? {});
-  const initResponse = useDevvitListener('GAME_INIT_RESPONSE');
-  const submissionResponse = useDevvitListener('WORD_SUBMITTED_RESPONSE');
-  const hintResponse = useDevvitListener('HINT_RESPONSE');
-  const giveUpResponse = useDevvitListener('GIVE_UP_RESPONSE');
+  const { appState } = useAppState();
 
-  // Just in case the game is not initialized
-  // This is old code left in for safety
-  useEffect(() => {
-    sendMessageToDevvit({
-      type: 'GAME_INIT',
-    });
-  }, []);
-
-  useEffect(() => {
-    logger.log('Init response: ', initResponse);
-    if (initResponse) {
-      setGame(initResponse);
-    }
-  }, [initResponse]);
-
-  useEffect(() => {
-    logger.log('Submission response: ', submissionResponse);
-    if (submissionResponse) {
-      setGame(submissionResponse);
-    }
-  }, [submissionResponse]);
-
-  useEffect(() => {
-    logger.log('Hint response: ', hintResponse);
-    if (hintResponse) {
-      setGame(hintResponse);
-    }
-  }, [hintResponse]);
-
-  useEffect(() => {
-    logger.log('Give up response: ', giveUpResponse);
-    if (giveUpResponse) {
-      setGame(giveUpResponse);
-    }
-  }, [giveUpResponse]);
-
-  return (
-    <GameUpdaterContext.Provider value={setGame}>
-      <GameContext.Provider value={game}>{children}</GameContext.Provider>
-    </GameUpdaterContext.Provider>
-  );
+  return <GameContext.Provider value={appState.game}>{children}</GameContext.Provider>;
 };
 
 export const useGame = () => {
@@ -67,12 +16,4 @@ export const useGame = () => {
     throw new Error('useGame must be used within a GameContextProvider');
   }
   return context;
-};
-
-export const useSetGame = () => {
-  const setGame = useContext(GameUpdaterContext);
-  if (setGame === null) {
-    throw new Error('useSetGame must be used within a GameContextProvider');
-  }
-  return setGame;
 };

--- a/packages/classic-webview/src/hooks/useHardcoreAccess.tsx
+++ b/packages/classic-webview/src/hooks/useHardcoreAccess.tsx
@@ -1,7 +1,6 @@
 import { HardcoreAccessStatus } from '@hotandcold/classic-shared';
-import { createContext, useContext, useEffect, useState } from 'react';
-import { useDevvitListener } from './useDevvitListener';
-import { useModal } from './useModal';
+import { createContext, useContext } from 'react';
+import { useAppState } from './useAppState';
 
 type HardcoreAccessContext = {
   access: HardcoreAccessStatus;
@@ -11,27 +10,15 @@ type HardcoreAccessContext = {
 const hardcoreAccessContext = createContext<HardcoreAccessContext | null>(null);
 
 export const HardcoreAccessContextProvider = (props: { children: React.ReactNode }) => {
-  const [access, setAccess] = useState<HardcoreAccessStatus>({ status: 'inactive' });
-  const hardcoreAccessInitResponse = useDevvitListener('HARDCORE_ACCESS_INIT_RESPONSE');
-  const productPurchaseResponse = useDevvitListener('PURCHASE_PRODUCT_SUCCESS_RESPONSE');
-  const { closeModal } = useModal();
-
-  useEffect(() => {
-    if (hardcoreAccessInitResponse?.hardcoreAccessStatus != null) {
-      setAccess(hardcoreAccessInitResponse.hardcoreAccessStatus);
-    }
-  }, [hardcoreAccessInitResponse, setAccess]);
-
-  // When a purchase is successful, update state and close the "Unlock Hardcore" modal
-  useEffect(() => {
-    if (productPurchaseResponse != null) {
-      setAccess(productPurchaseResponse.access);
-      closeModal();
-    }
-  }, [productPurchaseResponse, setAccess, closeModal]);
+  const { appState, setAccess } = useAppState();
 
   return (
-    <hardcoreAccessContext.Provider value={{ access, setAccess }}>
+    <hardcoreAccessContext.Provider
+      value={{
+        access: appState.hardcoreAccess,
+        setAccess,
+      }}
+    >
       {props.children}
     </hardcoreAccessContext.Provider>
   );

--- a/packages/classic-webview/src/hooks/usePage.tsx
+++ b/packages/classic-webview/src/hooks/usePage.tsx
@@ -1,29 +1,11 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 import { Page } from '@hotandcold/classic-shared';
-import { useGame } from './useGame';
-import { useHardcoreAccess } from './useHardcoreAccess';
 
 const PageContext = createContext<Page | null>(null);
 const PageUpdaterContext = createContext<React.Dispatch<React.SetStateAction<Page>> | null>(null);
 
 export const PageContextProvider = ({ children }: { children: React.ReactNode }) => {
   const [page, setPage] = useState<Page>('loading');
-  const game = useGame();
-  const { access } = useHardcoreAccess();
-
-  useEffect(() => {
-    if (
-      // Keep in sync with usePage's initializer
-      game.challengeUserInfo?.solvedAtMs ||
-      game.challengeUserInfo?.gaveUpAtMs
-    ) {
-      setPage('win');
-    } else if (game.mode === 'hardcore' && access.status === 'inactive') {
-      setPage('unlock-hardcore');
-    } else {
-      setPage('play');
-    }
-  }, [game, access, setPage]);
 
   return (
     <PageUpdaterContext.Provider value={setPage}>

--- a/packages/classic-webview/src/main.tsx
+++ b/packages/classic-webview/src/main.tsx
@@ -12,6 +12,7 @@ import { ConfirmationDialogProvider } from '@hotandcold/webview-common/hooks/use
 import { IS_DETACHED } from './constants';
 import { ModalContextProvider } from './hooks/useModal';
 import { HardcoreAccessContextProvider } from './hooks/useHardcoreAccess';
+import { AppStateContextProvider } from './hooks/useAppState';
 
 console.log('webview main called');
 
@@ -25,13 +26,15 @@ createRoot(document.getElementById('root')!).render(
       <ConfirmationDialogProvider>
         <ModalContextProvider>
           <UserSettingsContextProvider>
-            <HardcoreAccessContextProvider>
-              <GameContextProvider>
-                <PageContextProvider>
-                  <App />
-                </PageContextProvider>
-              </GameContextProvider>
-            </HardcoreAccessContextProvider>
+            <PageContextProvider>
+              <AppStateContextProvider>
+                <HardcoreAccessContextProvider>
+                  <GameContextProvider>
+                    <App />
+                  </GameContextProvider>
+                </HardcoreAccessContextProvider>
+              </AppStateContextProvider>
+            </PageContextProvider>
           </UserSettingsContextProvider>
         </ModalContextProvider>
       </ConfirmationDialogProvider>

--- a/packages/classic/src/payments.ts
+++ b/packages/classic/src/payments.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 
 export class PaymentsRepo {
   static hardcoreModeAccessKey(userId: string) {
-    return `hardcore-mode-access:${userId}`;
+    return `h_hardcore-mode-access:${userId}`;
   }
 
   #redis: RedisClient;


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
We have `useDevvitListeners` scattered in different context providers (namely `useGame`, `usePage`, `useHardcoreAccess`). Each context provider component has `useEffect` callbacks that react to state changes differently. This is hard to increasingly hard to reason about.

In order to _navigate to the hardcore post_ after purchase, we need to set the page to `play`. However, this callback depends on both game mode and access status (since for regular posts, this callback should close the modal instead of setting the page). This dependency causes a circular dependency between contexts. 

Thus, this PR was created to consolidate our context's state management to combat the aforementioned issue.




## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
