### PR TITLE
Hardcore Access state change logic

### DIFF
--- a/packages/classic-webview/src/components/UnlockHardcoreModal.tsx
+++ b/packages/classic-webview/src/components/UnlockHardcoreModal.tsx
@@ -1,9 +1,10 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useEffect } from 'react';
 import { HardcoreLogo } from '@hotandcold/webview-common/components/logo';
 import { GoldIcon } from '@hotandcold/webview-common/components/icon';
 import { cn } from '@hotandcold/webview-common/utils';
 import { Modal } from '@hotandcold/webview-common/components/modal';
 import { sendMessageToDevvit } from '../utils';
+import { useHardcoreAccess } from '../hooks/useHardcoreAccess';
 
 interface PurchaseButtonProps {
   children: React.ReactNode;
@@ -51,6 +52,15 @@ const PurchaseButton: React.FC<PurchaseButtonProps> = (props) => {
 type UnlockHardcoreModalProps = Omit<ComponentProps<typeof Modal>, 'children'>;
 
 export const UnlockHardcoreModal = (props: UnlockHardcoreModalProps) => {
+  const { access } = useHardcoreAccess();
+
+  useEffect(() => {
+    // if the access was activated
+    if (access.status === 'active') {
+      props.onClose();
+    }
+  }, [access]);
+
   return (
     <Modal {...props}>
       <div className="flex w-full max-w-md flex-col items-center justify-center gap-4 p-6 sm:gap-6 sm:p-8 md:max-w-2xl md:p-10">

--- a/packages/classic-webview/src/hooks/useHardcoreAccess.tsx
+++ b/packages/classic-webview/src/hooks/useHardcoreAccess.tsx
@@ -1,8 +1,6 @@
 import { HardcoreAccessStatus } from '@hotandcold/classic-shared';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { useDevvitListener } from './useDevvitListener';
-import { useModal } from './useModal';
-import { useGame } from './useGame';
 
 type HardcoreAccessContext = {
   access: HardcoreAccessStatus;
@@ -15,8 +13,6 @@ export const HardcoreAccessContextProvider = (props: { children: React.ReactNode
   const [access, setAccess] = useState<HardcoreAccessStatus>({ status: 'inactive' });
   const hardcoreAccessInitResponse = useDevvitListener('HARDCORE_ACCESS_INIT_RESPONSE');
   const productPurchaseResponse = useDevvitListener('PURCHASE_PRODUCT_SUCCESS_RESPONSE');
-  const { closeModal } = useModal();
-  const game = useGame();
 
   useEffect(() => {
     if (hardcoreAccessInitResponse?.hardcoreAccessStatus != null) {
@@ -24,18 +20,13 @@ export const HardcoreAccessContextProvider = (props: { children: React.ReactNode
     }
   }, [hardcoreAccessInitResponse, setAccess]);
 
-  // When a purchase is successful, update state and close the "Unlock Hardcore" modal
+  // When a purchase is successful, update 'access' state
+  // `unlock hardcore` page and modal should react to this and act accordingly
   useEffect(() => {
     if (productPurchaseResponse != null) {
       setAccess(productPurchaseResponse.access);
-      // Close the "Unlock Hardcore" modal in regular mode.
-      // For hardcore mode, we rely on the `pageContextProvider` to
-      // listen for `access` changes and update the page accordingly
-      if (game.mode === 'regular') {
-        closeModal();
-      }
     }
-  }, [productPurchaseResponse, setAccess, closeModal, game]);
+  }, [productPurchaseResponse, setAccess]);
 
   return (
     <hardcoreAccessContext.Provider value={{ access, setAccess }}>

--- a/packages/classic-webview/src/hooks/useHardcoreAccess.tsx
+++ b/packages/classic-webview/src/hooks/useHardcoreAccess.tsx
@@ -2,6 +2,7 @@ import { HardcoreAccessStatus } from '@hotandcold/classic-shared';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { useDevvitListener } from './useDevvitListener';
 import { useModal } from './useModal';
+import { useGame } from './useGame';
 
 type HardcoreAccessContext = {
   access: HardcoreAccessStatus;
@@ -15,6 +16,7 @@ export const HardcoreAccessContextProvider = (props: { children: React.ReactNode
   const hardcoreAccessInitResponse = useDevvitListener('HARDCORE_ACCESS_INIT_RESPONSE');
   const productPurchaseResponse = useDevvitListener('PURCHASE_PRODUCT_SUCCESS_RESPONSE');
   const { closeModal } = useModal();
+  const game = useGame();
 
   useEffect(() => {
     if (hardcoreAccessInitResponse?.hardcoreAccessStatus != null) {
@@ -26,9 +28,14 @@ export const HardcoreAccessContextProvider = (props: { children: React.ReactNode
   useEffect(() => {
     if (productPurchaseResponse != null) {
       setAccess(productPurchaseResponse.access);
-      closeModal();
+      // Close the "Unlock Hardcore" modal in regular mode.
+      // For hardcore mode, we rely on the `pageContextProvider` to
+      // listen for `access` changes and update the page accordingly
+      if (game.mode === 'regular') {
+        closeModal();
+      }
     }
-  }, [productPurchaseResponse, setAccess, closeModal]);
+  }, [productPurchaseResponse, setAccess, closeModal, game]);
 
   return (
     <hardcoreAccessContext.Provider value={{ access, setAccess }}>


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Only close the modal if it's a regular post. For hardcore posts, when a purchase is successful, the page context provider already has a `useEffect` listener on `access` that updates the page accordingly.

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
