### PR TITLE
Center tablist

### DIFF
--- a/packages/webview-common/src/components/tablist.tsx
+++ b/packages/webview-common/src/components/tablist.tsx
@@ -15,7 +15,7 @@ export const Tablist = ({ activeIndex, onChange, items }: TablistProps) => {
   };
 
   return (
-    <div role="tablist" className="inline-flex text-gray-600 dark:text-gray-400">
+    <div role="tablist" className="flex flex-wrap justify-center text-gray-600 dark:text-gray-400">
       {items.map((item, index) => (
         <button
           key={item.name}


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Fixes issue where the tablist on the WinPage starts translating the right when the viewport width hits around 390px. 
<img width="365" alt="Screenshot 2025-05-06 at 11 42 52 AM" src="https://github.com/user-attachments/assets/c29ffac0-9c4b-4361-991a-da60c1053494" />


## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
